### PR TITLE
Rename parcel-bundler to parcel

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "precommit": "run-p build lint"
   },
   "peerDependencies": {
-    "parcel-bundler": "^1.9.0",
+    "parcel": "^1.9.0",
     "typescript": "^2.4.0"
   },
   "dependencies": {

--- a/src/frontend/assets/js-asset.ts
+++ b/src/frontend/assets/js-asset.ts
@@ -1,9 +1,9 @@
 // tslint:disable:no-var-requires
 
-import JSAssetLib = require('parcel-bundler/lib/assets/JSAsset')
+import JSAssetLib = require('parcel/lib/assets/JSAsset')
 
 export const JSAsset: typeof JSAssetLib = parseInt(process.versions.node, 10) < 8
-	? require('parcel-bundler/lib/assets/JSAsset')
-	: require('parcel-bundler/src/assets/JSAsset')
+	? require('parcel/lib/assets/JSAsset')
+	: require('parcel/src/assets/JSAsset')
 
 export type JSAsset = JSAssetLib

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,4 +1,4 @@
-declare module 'parcel-bundler/lib/assets/JSAsset' {
+declare module 'parcel/lib/assets/JSAsset' {
 	class JSAsset {
 		public name: string
 		public relativeName: string
@@ -24,8 +24,8 @@ declare module 'parcel-bundler/lib/assets/JSAsset' {
 
 	export = JSAsset
 }
-declare module 'parcel-bundler/src/assets/JSAsset' {
-	import JSAsset = require('parcel-bundler/lib/assets/JSAsset')
+declare module 'parcel/src/assets/JSAsset' {
+	import JSAsset = require('parcel/lib/assets/JSAsset')
 
 	export = JSAsset
 }


### PR DESCRIPTION
Parcel Bundler can be installed from `parcel` name.
I think most people install Parcel from the name 'parcel' instead of 'parcel-bundler'.
I thought that you could apply it in this plugin.